### PR TITLE
Autodetect Prometheus port name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ### Installation
 
-```
-export PLUGIN_VERSION=1.0.5
+```bash
+export PLUGIN_VERSION=1.1.0
 
 # MacOS (x86_64)
 curl -sLo /usr/local/bin/kubectl-advisory https://github.com/elisasre/kubernetes-resource-advisor/releases/download/${PLUGIN_VERSION}/resource-advisor-darwin-amd64
@@ -26,9 +26,8 @@ The [prometheus-operator](https://github.com/prometheus-operator/prometheus-oper
 
 ### Usage
 
-```
-kubectl advisory --help
-I0916 13:28:02.492261   96935 start.go:23] Starting application...
+```bash
+% kubectl advisory --help
 Kubernetes resource-advisor
 
 Usage:
@@ -36,38 +35,37 @@ Usage:
 
 Flags:
   -h, --help                        help for resource-advisor
-      --limit-margin string         Limit margin (default "1.2")
-      --namespace-selector string   Namespace selector
-      --namespaces string           Comma separated namespaces to be scanned
-      --quantile string             Quantile to be used (default "0.95")
+  -m, --limit-margin string         Limit margin (default "1.2")
+  -l, --namespace-selector string   Namespace selector
+  -n, --namespaces string           Comma separated namespaces to be scanned
+  -q, --quantile string             Quantile to be used (default "0.95")
 ```
 
-```
+```bash
 % kubectl advisory
-I0916 13:26:56.442083   96863 start.go:23] Starting application...
 Namespaces: logging
 Quantile: 0.95
 Limit margin: 1.2
+Using mode: sum_irate
 +-----------+----------------------+------------+--------------------+--------------------+------------------+------------------+
 | NAMESPACE |       RESOURCE       | CONTAINER  | REQUEST CPU (SPEC) | REQUEST MEM (SPEC) | LIMIT CPU (SPEC) | LIMIT MEM (SPEC) |
 +-----------+----------------------+------------+--------------------+--------------------+------------------+------------------+
-| logging   | daemonset/fluent-bit | fluent-bit | 10m (25m)          | 100Mi (100Mi)      | 100m (400m)      | 100Mi (200Mi)    |
+| logging   | daemonset/fluent-bit | fluent-bit | 10m (25m)          | 100Mi (100Mi)      | 100m (400m)      | 200Mi (200Mi)    |
 +-----------+----------------------+------------+--------------------+--------------------+------------------+------------------+
 Total savings:
-You could save 0.32 vCPUs and 102.0 MB Memory by changing the settings
+You could save 0.27 vCPUs and 87.4 MB Memory by changing the settings
 ```
 
 What these numbers mean? The idea of this tool is to find out `quantile` (default is 95%) CPU & memory real usage for single POD using Prometheus operator. We use that real usage value for specifying `requests`. Then there is another variable called `limit-margin` which is used for specifying `limits`. The default settings means that 95% of time the POD has quarantee for the resources, and 5% of time it uses burstable capacity between 95% -> 120% of POD maximum usage in history.
 
-
 #### Using namespace-selector
 
-```
+```bash
 % kubectl advisory --namespace-selector maintainer=a_crowd_devops
-I0916 14:37:52.758305    5980 start.go:23] Starting application...
 Namespaces: actions-runner-system,cert-manager,default,gha,kaas-test-infra
 Quantile: 0.95
 Limit margin: 1.2
+Using mode: sum_irate
 +-----------------------+-------------------------------------------------+-----------------+--------------------+--------------------+------------------+------------------+
 |       NAMESPACE       |                    RESOURCE                     |    CONTAINER    | REQUEST CPU (SPEC) | REQUEST MEM (SPEC) | LIMIT CPU (SPEC) | LIMIT MEM (SPEC) |
 +-----------------------+-------------------------------------------------+-----------------+--------------------+--------------------+------------------+------------------+
@@ -85,14 +83,12 @@ You could save 0.12 vCPUs and -380.6 MB Memory by changing the settings
 
 #### Using as library
 
-```
-    import "github.com/elisasre/kubernetes-resource-advisor/pkg/advisor"
+```go
+import "github.com/elisasre/kubernetes-resource-advisor/pkg/advisor"
 
-    ...
-
-    response, err := advisor.Run(&advisor.Options{
-        Namespaces: "logging,monitoring",
-    })
+response, err := advisor.Run(&advisor.Options{
+    Namespaces: "logging,monitoring",
+})
 ```
 
 ### Motivation

--- a/pkg/advisor/main.go
+++ b/pkg/advisor/main.go
@@ -42,7 +42,8 @@ func Run(o *Options) (*Response, error) {
 		return nil, err
 	}
 	if len(prom_service.Items) == 0 || len(prom_service.Items[0].Spec.Ports) == 0 {
-		return nil, fmt.Errorf("Prometheus-operator not detected!")
+		return nil, fmt.Errorf("prometheus-operator not detected!")
+
 	}
 
 	o.promClient, err = makePrometheusClientForCluster(prom_service.Items[0].Namespace, prom_service.Items[0].Spec.Ports[0].Name)

--- a/pkg/advisor/main.go
+++ b/pkg/advisor/main.go
@@ -41,11 +41,11 @@ func Run(o *Options) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(prom_service.Items) == 0 {
+	if len(prom_service.Items) == 0 || len(prom_service.Items[0].Spec.Ports) == 0 {
 		return nil, fmt.Errorf("Prometheus-operator not detected!")
 	}
 
-	o.promClient, err = makePrometheusClientForCluster(prom_service.Items[0].Namespace)
+	o.promClient, err = makePrometheusClientForCluster(prom_service.Items[0].Namespace, prom_service.Items[0].Spec.Ports[0].Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/advisor/utils.go
+++ b/pkg/advisor/utils.go
@@ -58,7 +58,7 @@ func queryStatistic(ctx context.Context, client *promClient, request string, now
 	output := make(map[string]float64)
 	response, _, err := queryPrometheus(ctx, client, request, now)
 	if err != nil {
-		return output, fmt.Errorf("Error querying statistic %v", err)
+		return output, fmt.Errorf("error querying statistic %v", err)
 	}
 	asSamples := response.(prommodel.Vector)
 
@@ -181,7 +181,7 @@ func (o *Options) detectMode(ctx context.Context) (string, error) {
 	request := fmt.Sprintf(cpuUsage, "sum_irate")
 	response, _, err := queryPrometheus(ctx, o.promClient, request, now)
 	if err != nil {
-		return "", fmt.Errorf("Error detecting mode %v", err)
+		return "", fmt.Errorf("error detecting mode %v", err)
 	}
 	asSamples := response.(prommodel.Vector)
 	if len(asSamples) > 0 {
@@ -191,13 +191,13 @@ func (o *Options) detectMode(ctx context.Context) (string, error) {
 	request = fmt.Sprintf(cpuUsage, "sum_rate")
 	response, _, err = queryPrometheus(ctx, o.promClient, request, now)
 	if err != nil {
-		return "", fmt.Errorf("Error detecting mode %v", err)
+		return "", fmt.Errorf("error detecting mode %v", err)
 	}
 	asSamples = response.(prommodel.Vector)
 	if len(asSamples) > 0 {
 		return "sum_rate", nil
 	}
-	return "", fmt.Errorf("Could not find cpu mode")
+	return "", fmt.Errorf("could not find cpu mode")
 }
 
 func (c *promClient) URL(ep string, args map[string]string) *url.URL {

--- a/pkg/advisor/utils.go
+++ b/pkg/advisor/utils.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	promOperatorClusterURL = "%s/api/v1/namespaces/%s/services/prometheus-operated:web/proxy/"
+	promOperatorClusterURL = "%s/api/v1/namespaces/%s/services/prometheus-operated:%s/proxy/"
 	podCPURequest          = `quantile_over_time(%s, node_namespace_pod_container:container_cpu_usage_seconds_total:%s{pod="%s", container!=""}[1w])`
 	podCPULimit            = `max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:%s{pod="%s", container!=""}[1w]) * %s`
 	podMemoryRequest       = `quantile_over_time(%s, container_memory_working_set_bytes{pod="%s", container!=""}[1w]) / 1024 / 1024`
@@ -136,13 +136,13 @@ func findReplicaset(replicasets *appsv1.ReplicaSetList, dep appsv1.Deployment) (
 	return nil, fmt.Errorf("could not find replicaset for deployment '%s' gen '%v'", dep.Name, generation)
 }
 
-func makePrometheusClientForCluster(namespace string) (*promClient, error) {
+func makePrometheusClientForCluster(namespace string, portname string) (*promClient, error) {
 	config, _, err := findConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	promurl := fmt.Sprintf(promOperatorClusterURL, config.Host, namespace)
+	promurl := fmt.Sprintf(promOperatorClusterURL, config.Host, namespace, portname)
 	transport, err := rest.TransportFor(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It seems that Helm installer is using `http-web` as port name instead of `web` in Jsonnet installer:
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L3326