### PR TITLE
chore: use a token for dependabot PR workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,3 +58,4 @@ jobs:
         uses: elisa-actions/github-action-merge-dependabot@v3
         with:
           target: minor
+          github-token: ${{ secrets.DOPS_SRE_PAT }}


### PR DESCRIPTION
- Using the default token does not trigger main workflow which should be
  triggered
